### PR TITLE
Fix key links in README.md (except Contributing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 <div align="center">
 <h1>The Adorad Language</h1>
 
-[Adorad](https://github.com/AdoradLang/Adorad) |
-[Documentation](https://github.com/adorad/adorad/blob/master/doc/docs.md) |
-[Contributing](https://github.com/adorad/adorad/blob/master/CONTRIBUTING.md) |
-[Compiler design](https://github.com/adorad/adorad/blob/master/COMPILER.md)
+[Adorad](https://github.com/adorad/adorad) |
+[Documentation](https://github.com/adorad/adorad/blob/dev/docs/docs.md) |
+[Language design](https://github.com/adorad/adorad/blob/dev/docs/language-design.md) |
+[Contributing](https://github.com/adorad/adorad/blob/dev/CONTRIBUTING.md) |
+[Compiler design](https://github.com/adorad/adorad/blob/dev/docs/compiler.md)
 
 </div>
 <div align="center">


### PR DESCRIPTION
Fix main repo and docs links on the top.

NOTE: the "Contributing" link is *still broken*, because I have no idea where it should point to.