### PR TITLE
Fix documentation links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 <div align="center">
 <h1>The Adorad Language</h1>
 
-[Adorad](https://github.com/AdoradLang/Adorad) |
-[Documentation](https://github.com/adorad/adorad/blob/master/doc/docs.md) |
-[Contributing](https://github.com/adorad/adorad/blob/master/CONTRIBUTING.md) |
-[Compiler design](https://github.com/adorad/adorad/blob/master/COMPILER.md)
+[Adorad](https://github.com/adorad/adorad) |
+[Documentation](https://github.com/adorad/adorad/blob/dev/docs/docs.md) |
+[Compiler design](https://github.com/adorad/adorad/blob/dev/docs/compiler.md) |
+[Language design](https://github.com/adorad/adorad/blob/dev/docs/language-design.md)
 
 </div>
 <div align="center">


### PR DESCRIPTION
Looks like the organization changed, the default branch changed and I'm not sure whether there was ever a CONTRIBUTING.md file.